### PR TITLE
Fix. SFW test page

### DIFF
--- a/uniforce/lib/Cleantalk/USP/Security/Firewall.php
+++ b/uniforce/lib/Cleantalk/USP/Security/Firewall.php
@@ -129,6 +129,11 @@ class Firewall
                             $this->test_block = $result;
                         }
                     }
+			// Add check for test IP regardless of status
+			if ($module->test_ip && $result['ip'] === $module->test_ip) {
+				$result['status'] = 'DENY';  // Force block test IP
+				$this->test_block = $result;
+			}
                 }
 
 				// Prioritize


### PR DESCRIPTION
The SecFW test page doesn't work, and on line 124 I see this [code](https://github.com/CleanTalk/php-usp/blob/dev/uniforce/lib/Cleantalk/USP/Security/Firewall.php#L124):
`if (strpos('PASS', $result['status']) === false) {`

and I don't know why this code is needed, since the WordPress plugin doesn't have such a [check](https://github.com/CleanTalk/security-malware-firewall/blob/58242a706d9c3a29e29dbd1d7ae9fef5956d6204/lib/CleantalkSP/Security/Firewall.php#L125).

Without this check the test screen works, but I decided to leave it and added a forced DENY status for the test IP.